### PR TITLE
bpmn/performance: Add comments on Message Start Events

### DIFF
--- a/content/how-to/bpmn/tune-performance.md
+++ b/content/how-to/bpmn/tune-performance.md
@@ -74,11 +74,12 @@ Parallel joins in particular can also increase memory usage of the NATS service.
 Where possible, prefer exclusive branching and sequential execution.
 When a task requires concurrency, keep the amount of data processed and the complexity of the tasks to the minimum necessary.
 
-### Check Wildcards in Message Start events
+### Control wildcards in message start events
 
-BPMN message start tasks can start on any topic or datasource, however the performance of these events can vary depending on their configuration.
-If you have numerous message start tasks you may find that subscribing to an exact topic or limiting the subscription to a single wildcard will
-dramatically reduce the performance impact.
+BPMN message start tasks can start on any topic or data source. However, performance varies with the events that the start task subscribes to.
+
+Subscribing to multiple wildcards can especially drag performance.
+To avoid a possible performance hit, try to subscribe to an exact topic, or limit subscriptions to a single wildcard.
 
 ### Avoid loops
 

--- a/content/how-to/bpmn/tune-performance.md
+++ b/content/how-to/bpmn/tune-performance.md
@@ -74,6 +74,12 @@ Parallel joins in particular can also increase memory usage of the NATS service.
 Where possible, prefer exclusive branching and sequential execution.
 When a task requires concurrency, keep the amount of data processed and the complexity of the tasks to the minimum necessary.
 
+### Check Wildcards in Message Start events
+
+BPMN message start tasks can start on any topic or datasource, however the performance of these events can vary depending on their configuration.
+If you have numerous message start tasks you may find that subscribing to an exact topic or limiting the subscription to a single wildcard will
+dramatically reduce the performance impact.
+
 ### Avoid loops
 
 A BPMN process can loop back to a previous task node to repeat execution.


### PR DESCRIPTION
In https://gitlab.com/libremfg/bpmn-engine/-/merge_requests/239 we did some benchmarking on the new wildcard subscriptions which led to some performance optimisations being uncovered. As wyth payload size and parallel jobs, lets expose this to the user to allow them to make informed choices.