### PR TITLE
Change Libre Audit postgres checksum with addition of container labels

### DIFF
--- a/content/deploy/install/services.md
+++ b/content/deploy/install/services.md
@@ -59,6 +59,16 @@ Common values that are changed include:
 
    As you install services through Helm, their respective YAML files reference these secrets.
 
+## Add the Rhize Helm Chart Repository
+
+You must add the helm chart repository for Rhize.
+
+1. Add the Helm Chart Repository
+
+    ```bash
+    helm repo add libre https://gitlab.com/api/v4/projects/42214456/packages/helm/stable
+    ```
+
 ## Install and add roles for the DB {#db}
 
 You must install the {{< param db >}} database service first.

--- a/content/releases/checksums/v3.0.0-checksums.txt
+++ b/content/releases/checksums/v3.0.0-checksums.txt
@@ -32,4 +32,4 @@ sha256:c4217c0d5a3f079dd751570f725d381a327c1ab00189bd593ac221a86036c98e
 
 Libre Audit Postgres:
 registry.gitlab.com/libremfg/libre-audit/postgres:v3.0.0
-sha256:5f2ae291035575f2e5b682a4225ddfc7e1af0f1910ebb67931a580a00179addd
+sha256:fb18a4fcb22ad76d4b8e4c404a3a5faf4207835166061d99ffd36801064752ab


### PR DESCRIPTION
### Add
  - Add section on how to add the Libre helm chart repository 

### Change
  - Change Libre-Audit Postgres checksum as it was recently rebuilt to include container labels and default partition size